### PR TITLE
Remove N/A Twitter marker from Lucas Lonergan

### DIFF
--- a/data/authors/lucas.yml
+++ b/data/authors/lucas.yml
@@ -1,3 +1,2 @@
 Name: Lucas Lonergan
-Twitter: na
 Github: lucaslonergan


### PR DESCRIPTION
`Twitter: na` in the author file resolves to the twitter username @na when the blog is rendered which I think isn't intentional in this case.

Can you review this @lucaslonergan ?