### PR TITLE
Ensure that <footer> is inside the <body> flow content

### DIFF
--- a/themes/pivotal-ui/layouts/_default/single.html
+++ b/themes/pivotal-ui/layouts/_default/single.html
@@ -52,6 +52,6 @@
     </div>
   </div>
   {{ partial "footer.html" . }}
+  {{ partial "foot.html" . }}
 </body>
-{{ partial "foot.html" . }}
 </html>

--- a/themes/pivotal-ui/layouts/index.html
+++ b/themes/pivotal-ui/layouts/index.html
@@ -52,6 +52,6 @@
         </div>
       </div>
     </div>
+    {{ partial "foot.html" . }}
   </body>
-  {{ partial "foot.html" . }}
 </html>

--- a/themes/pivotal-ui/layouts/taxonomy/author.html
+++ b/themes/pivotal-ui/layouts/taxonomy/author.html
@@ -116,6 +116,6 @@
         </div>
       </div>
     </div>
+    {{ partial "foot.html" . }}
   </body>
-  {{ partial "foot.html" . }}
 </html>

--- a/themes/pivotal-ui/layouts/taxonomy/category.html
+++ b/themes/pivotal-ui/layouts/taxonomy/category.html
@@ -53,6 +53,6 @@
         </div>
       </div>
     </div>
+    {{ partial "foot.html" . }}
   </body>
-  {{ partial "foot.html" . }}
 </html>


### PR DESCRIPTION
The `<footer>` tag is not allowed outside of `<body>`, placing it there leads to HTML validation errors. Fix by moving foot.html inside the `<body>` content in rendering.