### PR TITLE
Finish off switch away from highlight.js to native highlighting

### DIFF
--- a/themes/pivotal-ui/layouts/_default/single.html
+++ b/themes/pivotal-ui/layouts/_default/single.html
@@ -54,7 +54,6 @@
       </figure>
     </div>
   </div>
-  {{ partial "footer.html" . }}
   {{ partial "foot.html" . }}
 </body>
 </html>

--- a/themes/pivotal-ui/layouts/partials/footer.html
+++ b/themes/pivotal-ui/layouts/partials/footer.html
@@ -1,3 +1,0 @@
-<link rel="stylesheet" href="/css/highlight-github.css">
-<script src="/js/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
Requests were observed to be made for highlight-github.css and highlight.pack.js for posts and were not present, yet we still see syntax highlighting in code blocks. It turns out that we are using
hugo's native highlighting on the server-side instead of highlight.js on the client-side since f4ccbe3 (Sun Feb 2, Cleans up highlightjs. Adjusts hugo highlighting to native theme), but we were still making requests for highlight.js resources.

Remove those unneeded vestiges.