### PR TITLE
Make responsive figure shortcode emit urls that respect hugo's baseURL

### DIFF
--- a/layouts/shortcodes/responsive-figure.html
+++ b/layouts/shortcodes/responsive-figure.html
@@ -2,7 +2,7 @@
 {{ if (.Get "class") }}
   <figure {{ with .Get "class" }}class="{{.}} fig-responsive"{{ end }}>
       {{ with .Get "link"}}<a href="{{.}}">{{ end }}
-          <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} />
+          <img src="{{ .Get "src" | relURL }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} />
       {{ if .Get "link"}}</a>{{ end }}
       {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
       <figcaption>{{ if isset .Params "title" }}
@@ -19,7 +19,7 @@
 {{ else }}
   <figure class="img-responsive">
       {{ with .Get "link"}}<a href="{{.}}">{{ end }}
-          <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} class="img-responsive" />
+          <img src="{{ .Get "src" | relURL }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} class="img-responsive" />
       {{ if .Get "link"}}</a>{{ end }}
       {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
       <figcaption>{{ if isset .Params "title" }}


### PR DESCRIPTION
The `relURL` function is flexible enough to accomodate assets that we may or may not host (eg. another domain).

https://gohugo.io/functions/relurl/
