### PR TITLE
ClusterRoleBinding roleRef correct name

### DIFF
--- a/content/post/secure-kubelet-metrics.md
+++ b/content/post/secure-kubelet-metrics.md
@@ -168,7 +168,7 @@ subjects:
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: test-kubelet-api
+  name: kubelet-api
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1


### PR DESCRIPTION
webhook auth did not work until the name for the ClusterRoleBinding was changed to match the name given in the ClusterRole: kubelet-api